### PR TITLE
fix(typings): generate d.ts files on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
-    "build:dist": "npm run clean:dist && npm run lint:dist && tsc -p src/ --outDir dist/ && npm run copy:dist",
+    "build:dist": "npm run clean:dist && npm run lint:dist && tsc -d -p src/ --outDir dist/ && npm run copy:dist",
     "build:docs": "rimraf _gh_pages && npm run lint:docs && webpack --progress --profile --bail",
     "build": "npm run build:dist",
     "copy:dist": "cp src/package.json dist/",

--- a/src/package.json
+++ b/src/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://orange-opensource.github.io/Orange-Boosted-Angular",
   "license":"MIT",
   "main": "index.js",
+  "typings": "index.d.ts",
   "peerDependencies": {
     "@angular/core": "^2.0.0",
     "@angular/common": "^2.0.0",


### PR DESCRIPTION
Fixes cannot find module 'ng-boosted' error (TS2307) upon `import { NgBoostedModule } from 'ng-boosted';`.