### PR TITLE
When building a project with 'ng build --prod', private variables used for the rendering provoke an error

### DIFF
--- a/src/o-dropdown/o-dropdown.component.ts
+++ b/src/o-dropdown/o-dropdown.component.ts
@@ -21,7 +21,7 @@ export class ODropdownComponent implements AfterViewInit {
     }
 
     @HostListener('openChange', ['$event'])
-    private handleDropdownFocus(isOpenEvent) {
+    public handleDropdownFocus(isOpenEvent) {
         if (isOpenEvent) {
             setTimeout(() => {
                 this.dropdownMenu.firstElementChild.focus();

--- a/src/scroll-top/scroll-top.component.ts
+++ b/src/scroll-top/scroll-top.component.ts
@@ -27,7 +27,7 @@ export class ScrollTopComponent {
   public label: string;
 
   @HostListener('window:scroll', [])
-  private onWindowScroll() {
+  public onWindowScroll() {
     if (document.documentElement.scrollTop > window.innerHeight) {
         this.showMe = true;
     } else {


### PR DESCRIPTION
When building a project with 'ng build --prod', I get this error :

``
[INFO] ERROR in (1,1): : Directive ScrollTopComponent, Property 'onWindowScroll' is private and only accessible within class 'ScrollTopComponent'.
[INFO] src/main/webapp/app/layouts/navbar/navbar.component.html(1,151): : Directive ODropdownComponent, Property 'handleDropdownFocus' is private and only accessible within class 'ODropdownComponent'.
``

The issue is that Angular, in AOT mode, expects properties used in the rendered template to be public : https://github.com/angular/angular-cli/issues/5623

https://github.com/Orange-OpenSource/Orange-Boosted-Angular/blob/0753598aeb408653d76c7b0f8b778d04c0a76aa2/src/scroll-top/scroll-top.component.ts#L30

https://github.com/Orange-OpenSource/Orange-Boosted-Angular/blob/0753598aeb408653d76c7b0f8b778d04c0a76aa2/src/o-dropdown/o-dropdown.component.ts#L24