### PR TITLE
Correction of an issue in IE11 : Swiper included in the TS way is in …

### DIFF
--- a/src/o-carousel/o-carousel-container.component.ts
+++ b/src/o-carousel/o-carousel-container.component.ts
@@ -17,7 +17,7 @@ import {
   OnInit
 } from '@angular/core';
 
-import Swiper from 'swiper';
+import Swiper from 'swiper/dist/js/swiper';
 
 @Injectable()
 @Component({


### PR DESCRIPTION
…ES6, hence not compatible with old browsers. We import directly the ES5 precompiled version instead.