### PR TITLE
fix a typo that prevent auto installing of the library dependencies

### DIFF
--- a/projects/ng-boosted/ng-package.json
+++ b/projects/ng-boosted/ng-package.json
@@ -3,5 +3,10 @@
   "dest": "../../dist/ng-boosted",
   "lib": {
     "entryFile": "src/public_api.ts"
-  }
+  },
+  "whitelistedNonPeerDependencies": [
+    "@ng-bootstrap/ng-bootstrap",
+    "boosted",
+    "swiper"
+  ]
 }

--- a/projects/ng-boosted/package.json
+++ b/projects/ng-boosted/package.json
@@ -14,7 +14,7 @@
     "@angular/common": "^8.0.0",
     "@angular/core": "^8.0.0"
   },
-  "dependecies": {
+  "dependencies": {
       "@ng-bootstrap/ng-bootstrap": "5.1.0",
       "boosted": "^4.3.1",
       "swiper": "^4.4.1"


### PR DESCRIPTION
in the ng-boosted library package.json there is a typo in dependencies (written dependecies) that prevent NPM from installing these dependencies when installing the library
also you need to explicitly whitelist these packages in ng-package.json to be able to build the library

fix https://github.com/Orange-OpenSource/Orange-Boosted-Angular/issues/105