### PR TITLE
fix a typo that prevent auto installing of the library dependencies

### DIFF
--- a/projects/ng-boosted/package.json
+++ b/projects/ng-boosted/package.json
@@ -14,7 +14,7 @@
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0"
   },
-  "dependecies": {
+  "dependencies": {
       "@ng-bootstrap/ng-bootstrap": "4.2.1",
       "boosted": "^4.3.1",
       "swiper": "^4.4.1"


### PR DESCRIPTION
in the ng-boosted library package.json there is a typo in dependencies (written dependecies) that prevent NPM from installing these dependencies when installing the library

fix https://github.com/Orange-OpenSource/Orange-Boosted-Angular/issues/115