### PR TITLE
fix: ONavMenuComponent selector

### DIFF
--- a/projects/ng-boosted/src/lib/o-carousel/o-carousel-container/o-carousel-container.component.ts
+++ b/projects/ng-boosted/src/lib/o-carousel/o-carousel-container/o-carousel-container.component.ts
@@ -82,22 +82,30 @@ import {
       });
     }
     @HostListener('mouseenter') public onMouseEnter() {
-      this.swiper.autoplay.stop();
+      if (this.swiper) {
+        this.swiper.autoplay.stop();
+      }
       this.pause = !this.pause;
     }
 
     @HostListener('mouseleave') public onMouseLeave() {
-      this.swiper.autoplay.start();
+      if (this.swiper) {
+        this.swiper.autoplay.start();
+      }
       this.pause = !this.pause;
     }
 
     @HostListener('focus') public onFocusIn() {
-      this.swiper.autoplay.start();
+      if (this.swiper) {
+        this.swiper.autoplay.start();
+      }
       this.pause = !this.pause;
     }
 
     @HostListener('blur') public onFocusOut() {
-      this.swiper.autoplay.start();
+      if (this.swiper) {
+        this.swiper.autoplay.start();
+      }
       this.pause = !this.pause;
     }
   }

--- a/projects/ng-boosted/src/lib/o-nav-menu/o-nav-menu.component.ts
+++ b/projects/ng-boosted/src/lib/o-nav-menu/o-nav-menu.component.ts
@@ -9,7 +9,8 @@
 import { Component, Input, HostBinding } from '@angular/core';
 
 @Component({
-    selector: 'lib-li[o-nav-menu]',
+  // tslint:disable-next-line:component-selector
+    selector: 'li[o-nav-menu]',
     styles: [`
       button {
         border: 0;


### PR DESCRIPTION
fix: change ONavMenuComponent selector from `lib-li[o-nav-menu]` to `li[o-nav-menu]` to be usable
add: tslint disable component-selector rule for the selector name of ONavMenuComponent

fix https://github.com/Orange-OpenSource/Orange-Boosted-Angular/issues/117