### PR TITLE
add safe check to OCarouselContainerComponent to prevent throwing errors

### DIFF
--- a/projects/ng-boosted/src/lib/o-carousel/o-carousel-container/o-carousel-container.component.ts
+++ b/projects/ng-boosted/src/lib/o-carousel/o-carousel-container/o-carousel-container.component.ts
@@ -82,22 +82,30 @@ import {
       });
     }
     @HostListener('mouseenter') public onMouseEnter() {
-      this.swiper.autoplay.stop();
+      if (this.swiper) {
+        this.swiper.autoplay.stop();
+      }
       this.pause = !this.pause;
     }
 
     @HostListener('mouseleave') public onMouseLeave() {
-      this.swiper.autoplay.start();
+      if (this.swiper) {
+        this.swiper.autoplay.start();
+      }
       this.pause = !this.pause;
     }
 
     @HostListener('focus') public onFocusIn() {
-      this.swiper.autoplay.start();
+      if (this.swiper) {
+        this.swiper.autoplay.start();
+      }
       this.pause = !this.pause;
     }
 
     @HostListener('blur') public onFocusOut() {
-      this.swiper.autoplay.start();
+      if (this.swiper) {
+        this.swiper.autoplay.start();
+      }
       this.pause = !this.pause;
     }
   }


### PR DESCRIPTION
fix: when an event trigger on OCarouselContainerComponent before swiper being initialized, it throw errors
  this commit tries to prevent that by add safe checks to make sure that swiper is defined before it tries to stop/start the autoplay

fix https://github.com/Orange-OpenSource/Orange-Boosted-Angular/issues/120